### PR TITLE
Bugfixes

### DIFF
--- a/playbooks/10 - SP - GDPR Framework/Create Data Compliance Record.json
+++ b/playbooks/10 - SP - GDPR Framework/Create Data Compliance Record.json
@@ -17,240 +17,6 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Create GDPR Data Compliance Record",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "name": "GDPR Assessment for Incident #{{vars.input.records[0].id}} - {{vars.input.records[0].name}}",
-                    "status": "\/api\/3\/picklists\/bb73fe9e-f699-11e7-8c3f-9a214cf093ae",
-                    "severity": "\/api\/3\/picklists\/40187287-89fc-4e9c-b717-e9443d57eedb",
-                    "testMode": "{{vars.testMode}}",
-                    "__replace": "",
-                    "incidents": "{{vars.input.records[0]['@id']}}",
-                    "testEmail": "{{vars.testEmail}}",
-                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-                    "recordTags": "{% if vars.testMode %}GDPR,Test Mode{% else %}GDPR{% endif %}",
-                    "assignedDate": "{{arrow.utcnow().int_timestamp}}",
-                    "breachDetectionDate": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachDetectionDate).int_timestamp}}",
-                    "breachNotifyDueDate": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachDetectionDate).shift(hours=+72).int_timestamp}}",
-                    "wasTheDataEncrypted": "{{vars.steps.Get_Data_Breach_Details.input.wasTheDataEncrypted}}",
-                    "breachOccurrenceDate": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachOccurrenceDate).int_timestamp}}",
-                    "regulatoryCompliance": "{{vars.steps.Get_Data_Breach_Details.input.regulatoryBody['@id']}}",
-                    "whatWasTheDataFormat": "{{vars.steps.Get_Data_Breach_Details.input.whatWasTheDataFormat}}",
-                    "whatWasTheDataSource": "{{vars.steps.Get_Data_Breach_Details.input.whatWasTheDataSource}}",
-                    "breachNotificationSLA": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                    "wasTheExposureResolved": "{{vars.steps.Get_Data_Breach_Details.input.wasTheExposureResolved}}",
-                    "wasPersonalDataAffected": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
-                    "isHarmRiskOrMisuseForeseeable": "{{vars.steps.Get_Data_Breach_Details.input.isHarmRiskOrMisuseForeseeable}}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/data_compliances",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "077a9cd3-1757-437b-9f35-cfba7109cbba"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Create Task GDPR Assessment",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "name": "Perform GDPR Assessment",
-                    "dueBy": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachOccurrenceDate).shift(hours=+72).int_timestamp}}",
-                    "priority": "\/api\/3\/picklists\/612befbc-4255-403a-958b-11efce3e1d8c",
-                    "__replace": "",
-                    "incidents": "{{vars.input.records[0]['@id']}}",
-                    "startDate": "{{arrow.utcnow().int_timestamp}}",
-                    "recordTags": [
-                        "\/api\/3\/tags\/GDPR Assessment"
-                    ],
-                    "description": "As per GDPR guidelines provided in [*Article - 33*](https:\/\/gdpr-info.eu\/art-33-gdpr\/), in the event of a personal data breach, it is mandatory to notify Data Protection Authority within 72 hours of the breach happening.\n\nBased on your information, the following GDPR Data Compliance record has been created.\n\n[GDPR Assessment Record #{{vars.steps.Create_GDPR_Data_Compliance_Record.id}}](https:\/\/{{globalVars.Server_fqhn}}\/modules\/incidents\/{{vars.steps.Create_GDPR_Data_Compliance_Record.uuid}})\n\nPerform the tasks provided in the record and complete the GDPR Assessment",
-                    "assignedOnDate": "{{arrow.utcnow().int_timestamp}}",
-                    "assignedToPerson": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/tasks",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "2c898db0-ee6d-4448-bda8-936831ffd10f"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Add Comment and Update GDPR SLA",
-            "description": null,
-            "arguments": {
-                "message": {
-                    "tags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "content": "<div>Thanks for your input.<\/div>\n<div>&nbsp;<\/div>\n<div><a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/data_compliances\/{{vars.steps.Create_GDPR_Data_Compliance_Record.uuid}}\">&nbsp;GDPR Compliance Record #{{vars.steps.Create_GDPR_Data_Compliance_Record.id}}<\/a> and corresponding <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.steps.Create_Task_GDPR_Assessment.uuid}}\">Task #{{vars.steps.Create_Task_GDPR_Assessment.id}} <\/a>has been created.<\/div>",
-                    "records": ""
-                },
-                "resource": [],
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "840",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "48907c29-21a3-4837-9781-2e0c094021e7"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Start",
-            "description": null,
-            "arguments": {
-                "message": {
-                    "tags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "content": "<p>Initiating Data Breach Risk Assessment.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
-                "resource": "incidents",
-                "resources": [
-                    "incidents"
-                ],
-                "step_variables": {
-                    "input": {
-                        "params": [],
-                        "records": [
-                            "{{vars.input.records[0]}}"
-                        ]
-                    }
-                },
-                "fieldbasedtrigger": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "object",
-                            "field": "wasPersonalDataAffected",
-                            "value": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
-                            "_value": {
-                                "@id": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
-                                "itemValue": "Yes"
-                            },
-                            "operator": "eq"
-                        },
-                        {
-                            "type": "object",
-                            "field": "wasPersonalDataAffected",
-                            "value": "",
-                            "_value": {
-                                "@id": "",
-                                "display": "",
-                                "itemValue": ""
-                            },
-                            "operator": "changed"
-                        }
-                    ]
-                }
-            },
-            "status": null,
-            "top": "30",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
-            "group": null,
-            "uuid": "5449ee4b-cf71-4995-9d56-95ab467a56bf"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Configuration",
-            "description": null,
-            "arguments": {
-                "testMode": "true",
-                "testEmail": "noreply@example.com"
-            },
-            "status": null,
-            "top": "160",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "575c53b4-0f71-45d6-be8a-03d7859ab484"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Regulatory Body",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "GDPR",
-                        "step_iri": "\/api\/3\/workflow_steps\/077a9cd3-1757-437b-9f35-cfba7109cbba",
-                        "condition": "{{ 'GDPR' == vars.steps.Get_Data_Breach_Details.input.regulatoryBody.itemValue }}",
-                        "step_name": "Create GDPR Data Compliance Record"
-                    },
-                    {
-                        "option": "Other",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/9f4c8071-85b0-404f-837a-14ae19e8d7a5",
-                        "step_name": "No Operation"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "435",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "50480294-a89c-4f18-bd59-776a2556d9c6"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "No Operation",
-            "description": null,
-            "arguments": {
-                "params": [],
-                "version": "3.2.1",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "9f4c8071-85b0-404f-837a-14ae19e8d7a5"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Get Data Breach Details",
             "description": null,
             "arguments": {
@@ -707,14 +473,359 @@
                 }
             },
             "status": null,
-            "top": "300",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "05e0f2ff-fb67-4c9a-ab87-23d3e66ce73a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create GDPR Data Compliance Record",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "name": "GDPR Assessment for Incident #{{vars.input.records[0].id}} - {{vars.input.records[0].name}}",
+                    "status": "\/api\/3\/picklists\/bb73fe9e-f699-11e7-8c3f-9a214cf093ae",
+                    "severity": "\/api\/3\/picklists\/40187287-89fc-4e9c-b717-e9443d57eedb",
+                    "testMode": "{{vars.testMode}}",
+                    "__replace": "",
+                    "incidents": "{{vars.input.records[0]['@id']}}",
+                    "testEmail": "{{vars.testEmail}}",
+                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
+                    "recordTags": "{% if vars.testMode %}GDPR,Test Mode{% else %}GDPR{% endif %}",
+                    "assignedDate": "{{arrow.utcnow().int_timestamp}}",
+                    "breachDetectionDate": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachDetectionDate).int_timestamp}}",
+                    "breachNotifyDueDate": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachDetectionDate).shift(hours=+72).int_timestamp}}",
+                    "wasTheDataEncrypted": "{{vars.steps.Get_Data_Breach_Details.input.wasTheDataEncrypted}}",
+                    "breachOccurrenceDate": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachOccurrenceDate).int_timestamp}}",
+                    "regulatoryCompliance": "{{vars.steps.Get_Data_Breach_Details.input.regulatoryBody['@id']}}",
+                    "whatWasTheDataFormat": "{{vars.steps.Get_Data_Breach_Details.input.whatWasTheDataFormat}}",
+                    "whatWasTheDataSource": "{{vars.steps.Get_Data_Breach_Details.input.whatWasTheDataSource}}",
+                    "breachNotificationSLA": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                    "wasTheExposureResolved": "{{vars.steps.Get_Data_Breach_Details.input.wasTheExposureResolved}}",
+                    "wasPersonalDataAffected": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
+                    "isHarmRiskOrMisuseForeseeable": "{{vars.steps.Get_Data_Breach_Details.input.isHarmRiskOrMisuseForeseeable}}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/data_compliances",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "077a9cd3-1757-437b-9f35-cfba7109cbba"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Add Comment to Incident",
+            "description": "Add a comment stating that the Data Compliance Record is already created for the Incident.",
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "__link": {
+                        "people": [],
+                        "incidents": "{{vars.input.records[0]['@id']}}"
+                    },
+                    "people": [],
+                    "content": "<div>Thanks for your input.<\/div>\n<div>&nbsp;<\/div>\n<div><a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/data_compliances\/{{vars.steps.Find_Correlated_Compliance_Record[0].dataCompliances[0].uuid}}\">&nbsp;GDPR Compliance Record #{{vars.steps.Find_Correlated_Compliance_Record[0].dataCompliances[0].id}}<\/a> and corresponding <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.steps.Find_Correlated_Compliance_Record[0].tasks[0].uuid}}\">Task #{{vars.steps.Find_Correlated_Compliance_Record[0].tasks[0].id}} <\/a>has already been created.<\/div>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Append",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "0b4af0e5-14c6-4ca8-92b3-c1c80322bf23"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Correlated Compliance Record",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "id",
+                            "value": "{{vars.input.records[0].id}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "dataCompliances",
+                        "tasks"
+                    ]
+                },
+                "module": "incidents?$limit=30&$relationships=true",
+                "checkboxFields": true,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "0dbe0dd0-de83-4222-a030-885c74b7ab08"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create Task GDPR Assessment",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "name": "Perform GDPR Assessment",
+                    "dueBy": "{{arrow.get(vars.steps.Get_Data_Breach_Details.input.breachOccurrenceDate).shift(hours=+72).int_timestamp}}",
+                    "priority": "\/api\/3\/picklists\/612befbc-4255-403a-958b-11efce3e1d8c",
+                    "__replace": "",
+                    "incidents": "{{vars.input.records[0]['@id']}}",
+                    "startDate": "{{arrow.utcnow().int_timestamp}}",
+                    "recordTags": [
+                        "\/api\/3\/tags\/GDPR Assessment"
+                    ],
+                    "description": "As per GDPR guidelines provided in [*Article - 33*](https:\/\/gdpr-info.eu\/art-33-gdpr\/), in the event of a personal data breach, it is mandatory to notify Data Protection Authority within 72 hours of the breach happening.\n\nBased on your information, the following GDPR Data Compliance record has been created.\n\n[GDPR Assessment Record #{{vars.steps.Create_GDPR_Data_Compliance_Record.id}}](https:\/\/{{globalVars.Server_fqhn}}\/modules\/incidents\/{{vars.steps.Create_GDPR_Data_Compliance_Record.uuid}})\n\nPerform the tasks provided in the record and complete the GDPR Assessment",
+                    "assignedOnDate": "{{arrow.utcnow().int_timestamp}}",
+                    "assignedToPerson": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/tasks",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "2c898db0-ee6d-4448-bda8-936831ffd10f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Correlated Complaiance Record Found",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/0b4af0e5-14c6-4ca8-92b3-c1c80322bf23",
+                        "condition": "{{ vars.steps.Find_Correlated_Compliance_Record[0].dataCompliances | length > 0 }}",
+                        "step_name": "Add Comment to Incident"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/05e0f2ff-fb67-4c9a-ab87-23d3e66ce73a",
+                        "step_name": "Get Data Breach Details"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "435",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "41eda0aa-b5f5-4f8d-a1f0-4c0358021ea2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Add Comment and Update GDPR SLA",
+            "description": null,
+            "arguments": {
+                "message": {
+                    "tags": [
+                        "\/api\/3\/tags\/GDPR"
+                    ],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "content": "<div>Thanks for your input.<\/div>\n<div>&nbsp;<\/div>\n<div><a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/data_compliances\/{{vars.steps.Create_GDPR_Data_Compliance_Record.uuid}}\">&nbsp;GDPR Compliance Record #{{vars.steps.Create_GDPR_Data_Compliance_Record.id}}<\/a> and corresponding <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.steps.Create_Task_GDPR_Assessment.uuid}}\">Task #{{vars.steps.Create_Task_GDPR_Assessment.id}} <\/a>has been created.<\/div>",
+                    "records": ""
+                },
+                "resource": [],
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "48907c29-21a3-4837-9781-2e0c094021e7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Regulatory Body",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "GDPR",
+                        "step_iri": "\/api\/3\/workflow_steps\/077a9cd3-1757-437b-9f35-cfba7109cbba",
+                        "condition": "{{ 'GDPR' == vars.steps.Get_Data_Breach_Details.input.regulatoryBody.itemValue }}",
+                        "step_name": "Create GDPR Data Compliance Record"
+                    },
+                    {
+                        "option": "Other",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/9f4c8071-85b0-404f-837a-14ae19e8d7a5",
+                        "step_name": "No Operation"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "705",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "50480294-a89c-4f18-bd59-776a2556d9c6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "message": {
+                    "tags": [
+                        "\/api\/3\/tags\/GDPR"
+                    ],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "content": "<p>Initiating Data Breach Risk Assessment.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
+                "resource": "incidents",
+                "resources": [
+                    "incidents"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    }
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "wasPersonalDataAffected",
+                            "value": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
+                                "itemValue": "Yes"
+                            },
+                            "operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "wasPersonalDataAffected",
+                            "value": "",
+                            "_value": {
+                                "@id": "",
+                                "display": "",
+                                "itemValue": ""
+                            },
+                            "operator": "changed"
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
+            "uuid": "5449ee4b-cf71-4995-9d56-95ab467a56bf"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "testMode": "true",
+                "testEmail": "noreply@example.com"
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "575c53b4-0f71-45d6-be8a-03d7859ab484"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "No Operation",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.1",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "9f4c8071-85b0-404f-837a-14ae19e8d7a5"
         }
     ],
     "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Find Correlated Compliance Record",
+            "targetStep": "\/api\/3\/workflow_steps\/0dbe0dd0-de83-4222-a030-885c74b7ab08",
+            "sourceStep": "\/api\/3\/workflow_steps\/575c53b4-0f71-45d6-be8a-03d7859ab484",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "4447e71e-954d-450e-be48-514aced141f9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Compliance Law -> HIPPA",
+            "targetStep": "\/api\/3\/workflow_steps\/9f4c8071-85b0-404f-837a-14ae19e8d7a5",
+            "sourceStep": "\/api\/3\/workflow_steps\/50480294-a89c-4f18-bd59-776a2556d9c6",
+            "label": "Other",
+            "isExecuted": false,
+            "uuid": "555d79d8-ac7a-4b53-8a21-772cd44644b4"
+        },
         {
             "@type": "WorkflowRoute",
             "name": "Start -> Configuration",
@@ -735,30 +846,21 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Compliance Law -> HIPPA",
-            "targetStep": "\/api\/3\/workflow_steps\/9f4c8071-85b0-404f-837a-14ae19e8d7a5",
-            "sourceStep": "\/api\/3\/workflow_steps\/50480294-a89c-4f18-bd59-776a2556d9c6",
-            "label": "Other",
-            "isExecuted": false,
-            "uuid": "555d79d8-ac7a-4b53-8a21-772cd44644b4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Compliance Law -> Create Data Compliance Record",
-            "targetStep": "\/api\/3\/workflow_steps\/077a9cd3-1757-437b-9f35-cfba7109cbba",
-            "sourceStep": "\/api\/3\/workflow_steps\/50480294-a89c-4f18-bd59-776a2556d9c6",
-            "label": "GDPR",
-            "isExecuted": false,
-            "uuid": "f053b8e2-c412-4526-86fe-0c5b099785d8"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Create Data Compliance Record -> Create Task GDPR Assessment",
             "targetStep": "\/api\/3\/workflow_steps\/2c898db0-ee6d-4448-bda8-936831ffd10f",
             "sourceStep": "\/api\/3\/workflow_steps\/077a9cd3-1757-437b-9f35-cfba7109cbba",
             "label": null,
             "isExecuted": false,
             "uuid": "6a8c277d-92e2-4494-b786-cb4b3b9b1511"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Correlated Compliance Record -> Is Correlated Complaiance Record Found",
+            "targetStep": "\/api\/3\/workflow_steps\/41eda0aa-b5f5-4f8d-a1f0-4c0358021ea2",
+            "sourceStep": "\/api\/3\/workflow_steps\/0dbe0dd0-de83-4222-a030-885c74b7ab08",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "a62576c7-4bf8-42f6-b8c8-4e4b130d657c"
         },
         {
             "@type": "WorkflowRoute",
@@ -771,12 +873,30 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Configuration -> Get Data Breach Details",
-            "targetStep": "\/api\/3\/workflow_steps\/05e0f2ff-fb67-4c9a-ab87-23d3e66ce73a",
-            "sourceStep": "\/api\/3\/workflow_steps\/575c53b4-0f71-45d6-be8a-03d7859ab484",
-            "label": null,
+            "name": "Is Corelated Complaiance Record Found -> Add Comment to Incident",
+            "targetStep": "\/api\/3\/workflow_steps\/0b4af0e5-14c6-4ca8-92b3-c1c80322bf23",
+            "sourceStep": "\/api\/3\/workflow_steps\/41eda0aa-b5f5-4f8d-a1f0-4c0358021ea2",
+            "label": "Yes",
             "isExecuted": false,
-            "uuid": "fcd1474e-7a64-4634-b635-57e97c753e76"
+            "uuid": "c96cb635-4dc5-4f3e-bc49-a62454b3c18c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Corelated Complaiance Record Found -> Get Data Breach Details",
+            "targetStep": "\/api\/3\/workflow_steps\/05e0f2ff-fb67-4c9a-ab87-23d3e66ce73a",
+            "sourceStep": "\/api\/3\/workflow_steps\/41eda0aa-b5f5-4f8d-a1f0-4c0358021ea2",
+            "label": "No",
+            "isExecuted": false,
+            "uuid": "db6922b0-a136-4a48-b505-ae878fb1d28e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Compliance Law -> Create Data Compliance Record",
+            "targetStep": "\/api\/3\/workflow_steps\/077a9cd3-1757-437b-9f35-cfba7109cbba",
+            "sourceStep": "\/api\/3\/workflow_steps\/50480294-a89c-4f18-bd59-776a2556d9c6",
+            "label": "GDPR",
+            "isExecuted": false,
+            "uuid": "f053b8e2-c412-4526-86fe-0c5b099785d8"
         }
     ],
     "groups": [],

--- a/playbooks/10 - SP - GDPR Framework/Get Breach Report Reviewed and Approved by DPO.json
+++ b/playbooks/10 - SP - GDPR Framework/Get Breach Report Reviewed and Approved by DPO.json
@@ -53,6 +53,55 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Create Task to Notify Affected Users",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High', 'Medium']}}",
+                "message": {
+                    "tags": [
+                        "\/api\/3\/tags\/GDPR"
+                    ],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "content": "<p>Created <a title=\"Task #{{vars.result.id}} - {{vars.result.name}}\" href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.result.uuid}}\">Task #{{vars.result.id}} - {{vars.result.name}}<\/a> to Notify Affected Individuals about Data Breach.<\/p>",
+                    "records": "{{vars.complianceIRI}}"
+                },
+                "resource": {
+                    "name": "Notify Affected Individuals",
+                    "type": "\/api\/3\/picklists\/d09e2bbf-bc2a-4d32-bf35-2a709f5a7b67",
+                    "dueBy": "{{vars.breachNotificationDueDate}}",
+                    "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
+                    "priority": "\/api\/3\/picklists\/90088ebe-0a7d-4aa6-9c9c-93b937a4e4f8",
+                    "__replace": "",
+                    "startDate": "{{arrow.utcnow().int_timestamp}}",
+                    "recordTags": [
+                        "\/api\/3\/tags\/Notify Affected Individuals"
+                    ],
+                    "description": "{{vars.demoMode}}\n\nBelow individuals are found to be at HIGH Risk by the data breach and need to be communicated about the same.\n<br>\n| Sr. No. | Affected Individuals |\n| --- | --- |\n{{vars.affectedIndividualsList | join('\\n')}}\n<br>\nClick on <span style=\"background: #5d636a; padding: 5px;\">**Notify Affected Individuals**<\/span> Button",
+                    "assignedOnDate": "{{arrow.utcnow().int_timestamp}}",
+                    "dataCompliances": "{{vars.complianceIRI}}",
+                    "assignedToPerson": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/tasks",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": {
+                    "_temp": "{% set item = vars.result['@id'] %}{% set _dummy = \"| 4 \" + \"|\" + (item | fromIRI).name + \"| [*Click Here*](https:\/\/\" + globalVars.Server_fqhn + \"\/modules\/view-panel\/tasks\/\" + (item | fromIRI).uuid + \")| <span>&#10060;<\/span>|\" %}{{vars.description.append(_dummy)}}"
+                }
+            },
+            "status": null,
+            "top": "1380",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "18efdf0e-6251-435e-b80c-81c30867fd32"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Configuration",
             "description": null,
             "arguments": {
@@ -493,6 +542,58 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Is Valid Breach",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a",
+                        "condition": "{{ 'Valid Breach' == vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isValidBreach }}",
+                        "step_name": "Add Comment for Valid Breach"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/f2eedf3c-c175-4072-8b1d-0bcb0c43d4f6",
+                        "step_name": "Update Task Status in Incident"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "1110",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "56b01d26-0f4d-41dc-b9f0-5961d7616dff"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Compliance Record Description",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "description": "{{vars.description | join('\\n')}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.complianceIRI}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/data_compliances",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1785",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "85f2df31-28bd-4819-a48a-63a9f6890b3c"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Update Task Status",
             "description": null,
             "arguments": {
@@ -515,6 +616,149 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "8efeed9e-7065-4186-b616-a96315419b6f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Task Description",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "description": "{{vars.demoMode}}\n\n##### DPO has confirmed an Invalid Breach. The Incident can be closed now."
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/tasks",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1380",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "a013832c-4f5e-418b-9d12-e02d5e6cc97c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create Task to Update Breach Report",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isReportDpoApproved == 'Rejected'}}",
+                "message": {
+                    "tags": [
+                        "\/api\/3\/tags\/GDPR"
+                    ],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "content": "<p>Created <a title=\"Task #{{vars.result.id}} - {{vars.result.name}}\" href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.result.uuid}}\">Task #{{vars.result.id}} - {{vars.result.name}}<\/a> to get updated data breach report from Data Protection Officer.<\/p>",
+                    "records": "{{vars.complianceIRI}}"
+                },
+                "resource": {
+                    "name": "Get Updated Report from DPO",
+                    "type": "\/api\/3\/picklists\/a6064def-fc9d-4d52-ac45-e0a55679c140",
+                    "dueBy": "{{vars.breachNotificationDueDate}}",
+                    "priority": "\/api\/3\/picklists\/90088ebe-0a7d-4aa6-9c9c-93b937a4e4f8",
+                    "__replace": "",
+                    "startDate": "{{arrow.utcnow().int_timestamp}}",
+                    "recordTags": [
+                        "\/api\/3\/tags\/Update Breach Report"
+                    ],
+                    "description": "{{vars.demoMode}}\n\nThe Data Breach Report was **Rejected** by DPO. To get updated data breach report from DPO.\n\nClick on <span style=\"background: #5d636a; padding: 5px;\">**Get Updated Breach Report**<\/span> Button\n\n\n",
+                    "assignedOnDate": "{{arrow.utcnow().int_timestamp}}",
+                    "dataCompliances": "{{vars.complianceIRI}}",
+                    "assignedToPerson": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/tasks",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": {
+                    "_temp": "{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High', 'Medium'] %}{% set item = vars.result['@id'] %}{% set _dummy = \"| 5 \" + \"|\" + (item | fromIRI).name + \"| [*Click Here*](https:\/\/\" + globalVars.Server_fqhn + \"\/modules\/view-panel\/tasks\/\" + (item | fromIRI).uuid + \")| <span>&#10060;<\/span>|\" %}{{vars.description.append(_dummy)}}{% else %}{% set item = vars.result['@id'] %}{% set _dummy = \"| 4 \" + \"|\" + (item | fromIRI).name + \"| [*Click Here*](https:\/\/\" + globalVars.Server_fqhn + \"\/modules\/view-panel\/tasks\/\" + (item | fromIRI).uuid + \")| <span>&#10060;<\/span>|\" %}{{vars.description.append(_dummy)}}{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "1515",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "b03e6c2a-94a3-454e-83a5-c9a6b1d01fb1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Add Comment for Valid Breach",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<p>DPO assessment of Data Breach Report is completed.<\/p>\n<p>&nbsp;<\/p>\n<p><span style=\"color: #236fa1;\"><em><strong>DPO Assessment Summary<\/strong><\/em><\/span><\/p>\n<ul>\n<li>This is a Valid Data Breach Incident<\/li>\n<li>{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High'] %}Affected individuals due to this breach are at <strong><span style=\"color: #ba372a;\">High<\/span><\/strong> risk. Hence, need to be communicated about the breach.{% elif vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['Medium'] %}Affected individuals due to this breach are at <strong><span style=\"color: #de7a13;\">Medium<\/span><\/strong> risk. Hence, need to be communicated about the breach.<\/li>\n<li>{% else %}Affected individuals due to this breach are at <strong><span style=\"color: #2dc26b;\">Low<\/span><\/strong> risk.{% endif %}<\/li>\n<li>{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isReportDpoApproved == 'Approved' %}Data Breach Report has been <span style=\"color: #2dc26b;\"><strong>Approved<\/strong><\/span> by DPO{% else %}Data Breach Report has been <span style=\"color: #ba372a;\"><strong>Rejected<\/strong><\/span> by DPO{% endif %}<\/li>\n<\/ul>",
+                    "__replace": "",
+                    "incidents": "{{vars.incidentIRI}}",
+                    "recordTags": [
+                        "\/api\/3\/tags\/GDPR"
+                    ],
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "dataCompliances": "{{vars.complianceIRI}}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Parent Incident ID",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "id",
+                            "value": "{{vars.complianceID}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "incidents"
+                    ]
+                },
+                "module": "data_compliances?$limit=30&$relationships=true",
+                "checkboxFields": true,
+                "step_variables": {
+                    "temp": "{% for item in vars.affectedUsersTempList %}{% set _dummy = \"|\" + loop.index | string + \"|\" + item + \"|\" %}{{vars.affectedIndividualsList.append(_dummy)}}{% endfor %}",
+                    "incidentIRI": "{{vars.result[0].incidents[0]['@id']}}"
+                }
+            },
+            "status": null,
+            "top": "440",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "bd094bb8-ce07-4434-be76-1a1b43d234cf"
         },
         {
             "@type": "WorkflowStep",
@@ -588,116 +832,6 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "d08ef5d7-19db-417c-91c3-d3631adbfb92"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Is Valid Breach",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a",
-                        "condition": "{{ 'Valid Breach' == vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isValidBreach }}",
-                        "step_name": "Add Comment for Valid Breach"
-                    },
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/f2eedf3c-c175-4072-8b1d-0bcb0c43d4f6",
-                        "step_name": "Update Task Status in Incident"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "1110",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "56b01d26-0f4d-41dc-b9f0-5961d7616dff"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Create Task to Notify Affected Users",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High', 'Medium']}}",
-                "message": {
-                    "tags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "content": "<p>Created <a title=\"Task #{{vars.result.id}} - {{vars.result.name}}\" href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.result.uuid}}\">Task #{{vars.result.id}} - {{vars.result.name}}<\/a> to Notify Affected Individuals about Data Breach.<\/p>",
-                    "records": "{{vars.complianceIRI}}"
-                },
-                "resource": {
-                    "name": "Notify Affected Individuals",
-                    "type": "\/api\/3\/picklists\/d09e2bbf-bc2a-4d32-bf35-2a709f5a7b67",
-                    "dueBy": "{{vars.breachNotificationDueDate}}",
-                    "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
-                    "priority": "\/api\/3\/picklists\/90088ebe-0a7d-4aa6-9c9c-93b937a4e4f8",
-                    "__replace": "",
-                    "startDate": "{{arrow.utcnow().int_timestamp}}",
-                    "recordTags": [
-                        "\/api\/3\/tags\/Notify Affected Individuals"
-                    ],
-                    "description": "{{vars.demoMode}}\n\nBelow individuals are found to be at HIGH Risk by the data breach and need to be communicated about the same.\n<br>\n| Sr. No. | Affected Individuals |\n| --- | --- |\n{{vars.affectedIndividualsList | join('\\n')}}\n<br>\nClick on <span style=\"background: #5d636a; padding: 5px;\">**Notify Affected Individuals**<\/span> Button",
-                    "assignedOnDate": "{{arrow.utcnow().int_timestamp}}",
-                    "dataCompliances": "{{vars.complianceIRI}}",
-                    "assignedToPerson": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/tasks",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": {
-                    "_temp": "{% set item = vars.result['@id'] %}{% set _dummy = \"| 4 \" + \"|\" + (item | fromIRI).name + \"| [*Click Here*](https:\/\/\" + globalVars.Server_fqhn + \"\/modules\/view-panel\/tasks\/\" + (item | fromIRI).uuid + \")| <span>&#10060;<\/span>|\" %}{{vars.description.append(_dummy)}}"
-                }
-            },
-            "status": null,
-            "top": "1380",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "18efdf0e-6251-435e-b80c-81c30867fd32"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Add Comment for Valid Breach",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "people": [],
-                    "content": "<p>DPO assessment of Data Breach Report is completed.<\/p>\n<p>&nbsp;<\/p>\n<p><span style=\"color: #236fa1;\"><em><strong>DPO Assessment Summary<\/strong><\/em><\/span><\/p>\n<ul>\n<li>This as a Valid Data Breach Incident<\/li>\n<li>{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High', 'Medium'] %}Affected individuals due to this breach are at <strong><span style=\"color: #ba372a;\">High<\/span><\/strong> risk. Hence, need to be communicate about the breach.{% else %}Affected individuals due to this breach are at <strong><span style=\"color: #2dc26b;\">Low<\/span><\/strong> risk.{% endif %}<\/li>\n<li>{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isReportDpoApproved == 'Approved' %}Data Breach Report has been <span style=\"color: #2dc26b;\"><strong>Approved<\/strong><\/span> by DPO{% else %}Data Breach Report has been <span style=\"color: #ba372a;\"><strong>Rejected<\/strong><\/span> by DPO{% endif %}<\/li>\n<\/ul>",
-                    "__replace": "",
-                    "incidents": "{{vars.incidentIRI}}",
-                    "recordTags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "isImportant": false,
-                    "peopleUpdated": false,
-                    "dataCompliances": "{{vars.complianceIRI}}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/comments",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1245",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a"
         },
         {
             "@type": "WorkflowStep",
@@ -781,188 +915,9 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "f2eedf3c-c175-4072-8b1d-0bcb0c43d4f6"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Compliance Record Description",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "description": "{{vars.description | join('\\n')}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.complianceIRI}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/data_compliances",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1785",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "85f2df31-28bd-4819-a48a-63a9f6890b3c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Create Task to Update Breach Report",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isReportDpoApproved == 'Rejected'}}",
-                "message": {
-                    "tags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "content": "<p>Created <a title=\"Task #{{vars.result.id}} - {{vars.result.name}}\" href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.result.uuid}}\">Task #{{vars.result.id}} - {{vars.result.name}}<\/a> to get updated data breach report from Data Protection Officer.<\/p>",
-                    "records": "{{vars.complianceIRI}}"
-                },
-                "resource": {
-                    "name": "Get Updated Report from DPO",
-                    "type": "\/api\/3\/picklists\/a6064def-fc9d-4d52-ac45-e0a55679c140",
-                    "dueBy": "{{vars.breachNotificationDueDate}}",
-                    "priority": "\/api\/3\/picklists\/90088ebe-0a7d-4aa6-9c9c-93b937a4e4f8",
-                    "__replace": "",
-                    "startDate": "{{arrow.utcnow().int_timestamp}}",
-                    "recordTags": [
-                        "\/api\/3\/tags\/Update Breach Report"
-                    ],
-                    "description": "{{vars.demoMode}}\n\nThe Data Breach Report was **Rejected** by DPO. To get updated data breach report from DPO.\n\nClick on <span style=\"background: #5d636a; padding: 5px;\">**Get Updated Breach Report**<\/span> Button\n\n\n",
-                    "assignedOnDate": "{{arrow.utcnow().int_timestamp}}",
-                    "dataCompliances": "{{vars.complianceIRI}}",
-                    "assignedToPerson": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/tasks",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": {
-                    "_temp": "{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High', 'Medium'] %}{% set item = vars.result['@id'] %}{% set _dummy = \"| 5 \" + \"|\" + (item | fromIRI).name + \"| [*Click Here*](https:\/\/\" + globalVars.Server_fqhn + \"\/modules\/view-panel\/tasks\/\" + (item | fromIRI).uuid + \")| <span>&#10060;<\/span>|\" %}{{vars.description.append(_dummy)}}{% else %}{% set item = vars.result['@id'] %}{% set _dummy = \"| 4 \" + \"|\" + (item | fromIRI).name + \"| [*Click Here*](https:\/\/\" + globalVars.Server_fqhn + \"\/modules\/view-panel\/tasks\/\" + (item | fromIRI).uuid + \")| <span>&#10060;<\/span>|\" %}{{vars.description.append(_dummy)}}{% endif %}"
-                }
-            },
-            "status": null,
-            "top": "1515",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "b03e6c2a-94a3-454e-83a5-c9a6b1d01fb1"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Parent Incident ID",
-            "description": null,
-            "arguments": {
-                "query": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "primitive",
-                            "field": "id",
-                            "value": "{{vars.complianceID}}",
-                            "operator": "eq",
-                            "_operator": "eq"
-                        }
-                    ],
-                    "__selectFields": [
-                        "incidents"
-                    ]
-                },
-                "module": "data_compliances?$limit=30&$relationships=true",
-                "checkboxFields": true,
-                "step_variables": {
-                    "temp": "{% for item in vars.affectedUsersTempList %}{% set _dummy = \"|\" + loop.index | string + \"|\" + item + \"|\" %}{{vars.affectedIndividualsList.append(_dummy)}}{% endfor %}",
-                    "incidentIRI": "{{vars.result[0].incidents[0]['@id']}}"
-                }
-            },
-            "status": null,
-            "top": "440",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
-            "group": null,
-            "uuid": "bd094bb8-ce07-4434-be76-1a1b43d234cf"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Task Description",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "description": "{{vars.demoMode}}\n\n##### DPO has confirmed an Invalid Breach. The Incident can be closed now."
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/tasks",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1380",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "a013832c-4f5e-418b-9d12-e02d5e6cc97c"
         }
     ],
     "routes": [
-        {
-            "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/1fb758b2-3161-4ad5-a13b-e74a86ea4e74",
-            "sourceStep": "\/api\/3\/workflow_steps\/453ae9dd-e8bc-401d-8ca1-ab3927b0f1ee",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "5d650097-fc54-4c75-b2aa-cbb68de163e8"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Assessment Data Table -> Send Risk Assessment Details to DPO",
-            "targetStep": "\/api\/3\/workflow_steps\/2ad8e881-37f7-4726-a2b5-037695dd649b",
-            "sourceStep": "\/api\/3\/workflow_steps\/0c229645-0f28-4f04-97ec-4815235dc40c",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "ec23904f-756e-4ea7-b297-4a211e1c45bf"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Configuration -> Get Incident ID",
-            "targetStep": "\/api\/3\/workflow_steps\/c0183c62-3aa1-41d9-970d-63526bb9f682",
-            "sourceStep": "\/api\/3\/workflow_steps\/1fb758b2-3161-4ad5-a13b-e74a86ea4e74",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "f4cf481d-b3f3-4bd0-8c07-0342aef52372"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Send Risk Assessment Details to DPO -> Update GDPR Assessment Data",
-            "targetStep": "\/api\/3\/workflow_steps\/d08ef5d7-19db-417c-91c3-d3631adbfb92",
-            "sourceStep": "\/api\/3\/workflow_steps\/2ad8e881-37f7-4726-a2b5-037695dd649b",
-            "label": "Submit",
-            "isExecuted": false,
-            "uuid": "c9500e34-6562-49a1-8daa-fec619215be4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is Valid Breach -> Add Comment for Valid Breach",
-            "targetStep": "\/api\/3\/workflow_steps\/bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a",
-            "sourceStep": "\/api\/3\/workflow_steps\/56b01d26-0f4d-41dc-b9f0-5961d7616dff",
-            "label": "Yes",
-            "isExecuted": false,
-            "uuid": "a8ef6577-a72e-4bec-a6a8-00c6524f1e08"
-        },
         {
             "@type": "WorkflowRoute",
             "name": "Is Valid Breach -> Update Task Status in Incident",
@@ -974,30 +929,30 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update GDPR Assessment Data -> Update Task Status",
-            "targetStep": "\/api\/3\/workflow_steps\/8efeed9e-7065-4186-b616-a96315419b6f",
-            "sourceStep": "\/api\/3\/workflow_steps\/d08ef5d7-19db-417c-91c3-d3631adbfb92",
+            "name": "Get Breach Report Updated by DPO -> Create Task to Send Report to DPA",
+            "targetStep": "\/api\/3\/workflow_steps\/d6b9971b-9a6c-460a-b71f-5bf0dec81abb",
+            "sourceStep": "\/api\/3\/workflow_steps\/b03e6c2a-94a3-454e-83a5-c9a6b1d01fb1",
             "label": null,
             "isExecuted": false,
-            "uuid": "d1f55701-cd7f-40fc-a36e-261946fb6b07"
+            "uuid": "4933edcf-2dcf-40f2-8ba9-378db065d3a7"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Task Status -> Is Valid Breach",
-            "targetStep": "\/api\/3\/workflow_steps\/56b01d26-0f4d-41dc-b9f0-5961d7616dff",
-            "sourceStep": "\/api\/3\/workflow_steps\/8efeed9e-7065-4186-b616-a96315419b6f",
+            "name": "Get Incident ID -> Create Assessment Data Table",
+            "targetStep": "\/api\/3\/workflow_steps\/0c229645-0f28-4f04-97ec-4815235dc40c",
+            "sourceStep": "\/api\/3\/workflow_steps\/bd094bb8-ce07-4434-be76-1a1b43d234cf",
             "label": null,
             "isExecuted": false,
-            "uuid": "cc706b32-7eb0-495c-af64-1cc5a2acd9a9"
+            "uuid": "4cfd0e8d-23e6-42f8-9ecc-32b294b998a9"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Add Comment for Valid Breach -> Create Task to Notify Affected Users",
-            "targetStep": "\/api\/3\/workflow_steps\/18efdf0e-6251-435e-b80c-81c30867fd32",
-            "sourceStep": "\/api\/3\/workflow_steps\/bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/1fb758b2-3161-4ad5-a13b-e74a86ea4e74",
+            "sourceStep": "\/api\/3\/workflow_steps\/453ae9dd-e8bc-401d-8ca1-ab3927b0f1ee",
             "label": null,
             "isExecuted": false,
-            "uuid": "8638d27f-fc64-4bc7-94d4-cbb2ac110da3"
+            "uuid": "5d650097-fc54-4c75-b2aa-cbb68de163e8"
         },
         {
             "@type": "WorkflowRoute",
@@ -1010,12 +965,57 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Breach Report Updated by DPO -> Create Task to Send Report to DPA",
-            "targetStep": "\/api\/3\/workflow_steps\/d6b9971b-9a6c-460a-b71f-5bf0dec81abb",
-            "sourceStep": "\/api\/3\/workflow_steps\/b03e6c2a-94a3-454e-83a5-c9a6b1d01fb1",
+            "name": "Add Comment for Valid Breach -> Create Task to Notify Affected Users",
+            "targetStep": "\/api\/3\/workflow_steps\/18efdf0e-6251-435e-b80c-81c30867fd32",
+            "sourceStep": "\/api\/3\/workflow_steps\/bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a",
             "label": null,
             "isExecuted": false,
-            "uuid": "4933edcf-2dcf-40f2-8ba9-378db065d3a7"
+            "uuid": "8638d27f-fc64-4bc7-94d4-cbb2ac110da3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Resolve Compliance Record -> Copy of Update Task Status",
+            "targetStep": "\/api\/3\/workflow_steps\/a013832c-4f5e-418b-9d12-e02d5e6cc97c",
+            "sourceStep": "\/api\/3\/workflow_steps\/f2eedf3c-c175-4072-8b1d-0bcb0c43d4f6",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "a322f0e4-c494-46ad-936f-3e18f9fcb0c9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Valid Breach -> Add Comment for Valid Breach",
+            "targetStep": "\/api\/3\/workflow_steps\/bcb980e9-19b9-4ecd-bdeb-70bdc2d7fe5a",
+            "sourceStep": "\/api\/3\/workflow_steps\/56b01d26-0f4d-41dc-b9f0-5961d7616dff",
+            "label": "Yes",
+            "isExecuted": false,
+            "uuid": "a8ef6577-a72e-4bec-a6a8-00c6524f1e08"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Send Risk Assessment Details to DPO -> Update GDPR Assessment Data",
+            "targetStep": "\/api\/3\/workflow_steps\/d08ef5d7-19db-417c-91c3-d3631adbfb92",
+            "sourceStep": "\/api\/3\/workflow_steps\/2ad8e881-37f7-4726-a2b5-037695dd649b",
+            "label": "Submit",
+            "isExecuted": false,
+            "uuid": "c9500e34-6562-49a1-8daa-fec619215be4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Task Status -> Is Valid Breach",
+            "targetStep": "\/api\/3\/workflow_steps\/56b01d26-0f4d-41dc-b9f0-5961d7616dff",
+            "sourceStep": "\/api\/3\/workflow_steps\/8efeed9e-7065-4186-b616-a96315419b6f",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "cc706b32-7eb0-495c-af64-1cc5a2acd9a9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update GDPR Assessment Data -> Update Task Status",
+            "targetStep": "\/api\/3\/workflow_steps\/8efeed9e-7065-4186-b616-a96315419b6f",
+            "sourceStep": "\/api\/3\/workflow_steps\/d08ef5d7-19db-417c-91c3-d3631adbfb92",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "d1f55701-cd7f-40fc-a36e-261946fb6b07"
         },
         {
             "@type": "WorkflowRoute",
@@ -1037,21 +1037,21 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Incident ID -> Create Assessment Data Table",
-            "targetStep": "\/api\/3\/workflow_steps\/0c229645-0f28-4f04-97ec-4815235dc40c",
-            "sourceStep": "\/api\/3\/workflow_steps\/bd094bb8-ce07-4434-be76-1a1b43d234cf",
+            "name": "Create Assessment Data Table -> Send Risk Assessment Details to DPO",
+            "targetStep": "\/api\/3\/workflow_steps\/2ad8e881-37f7-4726-a2b5-037695dd649b",
+            "sourceStep": "\/api\/3\/workflow_steps\/0c229645-0f28-4f04-97ec-4815235dc40c",
             "label": null,
             "isExecuted": false,
-            "uuid": "4cfd0e8d-23e6-42f8-9ecc-32b294b998a9"
+            "uuid": "ec23904f-756e-4ea7-b297-4a211e1c45bf"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Resolve Compliance Record -> Copy of Update Task Status",
-            "targetStep": "\/api\/3\/workflow_steps\/a013832c-4f5e-418b-9d12-e02d5e6cc97c",
-            "sourceStep": "\/api\/3\/workflow_steps\/f2eedf3c-c175-4072-8b1d-0bcb0c43d4f6",
+            "name": "Configuration -> Get Incident ID",
+            "targetStep": "\/api\/3\/workflow_steps\/c0183c62-3aa1-41d9-970d-63526bb9f682",
+            "sourceStep": "\/api\/3\/workflow_steps\/1fb758b2-3161-4ad5-a13b-e74a86ea4e74",
             "label": null,
             "isExecuted": false,
-            "uuid": "a322f0e4-c494-46ad-936f-3e18f9fcb0c9"
+            "uuid": "f4cf481d-b3f3-4bd0-8c07-0342aef52372"
         }
     ],
     "groups": [],

--- a/playbooks/10 - SP - GDPR Framework/Get GDPR Risk Assessment Details.json
+++ b/playbooks/10 - SP - GDPR Framework/Get GDPR Risk Assessment Details.json
@@ -562,20 +562,6 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Configuration",
-            "description": null,
-            "arguments": {
-                "description": "[]"
-            },
-            "status": null,
-            "top": "165",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "df160913-cf18-42c2-8a14-c48e55d08daf"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Get Parent Incident ID",
             "description": null,
             "arguments": {
@@ -611,12 +597,28 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "description": "[]"
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "df160913-cf18-42c2-8a14-c48e55d08daf"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Update Compliance Record Description",
             "description": null,
             "arguments": {
                 "resource": {
+                    "status": "\/api\/3\/picklists\/bb7402d6-f699-11e7-8c3f-9a214cf093ae",
                     "description": "{{vars.description | join('\\n')}}"
                 },
+                "_showJson": false,
                 "operation": "Append",
                 "collection": "{{vars.complianceIRI}}",
                 "__recommend": [],
@@ -644,12 +646,21 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Configuration -> Get Incident ID",
-            "targetStep": "\/api\/3\/workflow_steps\/b13d127d-00e8-476e-a531-657675ce1515",
-            "sourceStep": "\/api\/3\/workflow_steps\/df160913-cf18-42c2-8a14-c48e55d08daf",
+            "name": "Update GDPR Assessment Data -> Update Task Status",
+            "targetStep": "\/api\/3\/workflow_steps\/d3a0acd0-3a26-4e69-af7a-43718b36ed76",
+            "sourceStep": "\/api\/3\/workflow_steps\/57671b9b-fa3b-4477-a3ff-a9b3576e8673",
             "label": null,
             "isExecuted": false,
-            "uuid": "c188ce12-621b-46f4-a55a-2a8df8f78e47"
+            "uuid": "20c758bc-3b4b-4088-acf7-be5c74cae074"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Task Status -> Update Compliance Record Description",
+            "targetStep": "\/api\/3\/workflow_steps\/f0f1f024-f9af-4342-9d8f-4f1622ba79d1",
+            "sourceStep": "\/api\/3\/workflow_steps\/d3a0acd0-3a26-4e69-af7a-43718b36ed76",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "740d8e6d-b18f-4158-a2a9-71b0b8f7133f"
         },
         {
             "@type": "WorkflowRoute",
@@ -671,21 +682,12 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update GDPR Assessment Data -> Update Task Status",
-            "targetStep": "\/api\/3\/workflow_steps\/d3a0acd0-3a26-4e69-af7a-43718b36ed76",
-            "sourceStep": "\/api\/3\/workflow_steps\/57671b9b-fa3b-4477-a3ff-a9b3576e8673",
+            "name": "Configuration -> Get Incident ID",
+            "targetStep": "\/api\/3\/workflow_steps\/b13d127d-00e8-476e-a531-657675ce1515",
+            "sourceStep": "\/api\/3\/workflow_steps\/df160913-cf18-42c2-8a14-c48e55d08daf",
             "label": null,
             "isExecuted": false,
-            "uuid": "20c758bc-3b4b-4088-acf7-be5c74cae074"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update Task Status -> Update Compliance Record Description",
-            "targetStep": "\/api\/3\/workflow_steps\/f0f1f024-f9af-4342-9d8f-4f1622ba79d1",
-            "sourceStep": "\/api\/3\/workflow_steps\/d3a0acd0-3a26-4e69-af7a-43718b36ed76",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "740d8e6d-b18f-4158-a2a9-71b0b8f7133f"
+            "uuid": "c188ce12-621b-46f4-a55a-2a8df8f78e47"
         }
     ],
     "groups": [],

--- a/playbooks/10 - SP - GDPR Framework/Send Data Breach Report to DPA.json
+++ b/playbooks/10 - SP - GDPR Framework/Send Data Breach Report to DPA.json
@@ -17,29 +17,79 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Generate Breach Report",
+            "name": "Update Compliance Record",
             "description": null,
             "arguments": {
-                "name": "Report Engine",
-                "params": {
-                    "user_id": "{{vars.currentUser}}",
-                    "timezone": "{{vars.request.headers.tz}}",
-                    "report_id": "bd3f7e9b-45ba-4740-a617-164887fc754c",
-                    "query_params": "{\"qparam\": {\"complianceID\":{{vars.complianceID}}}}"
+                "message": {
+                    "tags": [
+                        "\/api\/3\/tags\/GDPR"
+                    ],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "content": "<p>Data Breach Report has been sent to Data Protection Authority.<\/p>",
+                    "records": "{{vars.complianceIRI}},{{vars.incidentIRI}}"
                 },
-                "version": "1.3.1",
-                "connector": "cyops-schedule-report",
-                "operation": "schedule_report_manual",
-                "operationTitle": "Generate Report From Report ID",
-                "pickFromTenant": false,
+                "resource": {
+                    "status": "\/api\/3\/picklists\/bb73fd5e-f699-11e7-8c3f-9a214cf093ae",
+                    "description": "{{vars.description | join('\\n')}}",
+                    "resolvedDate": "{{arrow.utcnow().int_timestamp}}",
+                    "breachNotifiedOn": "{{arrow.utcnow().int_timestamp}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.complianceIRI}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/data_compliances",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "1110",
             "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
-            "uuid": "ae5f6b3b-70ce-4271-8f4b-c57cb3c40dd2"
+            "uuid": "1b231c10-7a36-49e3-bc1d-c86d1f2ca09e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "description": "[]"
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "2efd605d-779e-44a0-a8e3-cbb0f3c08b55"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Breach Notified On Date",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "breachNotifiedOn": "{{arrow.utcnow().int_timestamp}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.complianceIRI}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/data_compliances",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "384da049-c718-4cff-af68-51107f92c56f"
         },
         {
             "@type": "WorkflowStep",
@@ -76,17 +126,133 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Configuration",
+            "name": "Update Task Status",
             "description": null,
             "arguments": {
-                "description": "[]"
+                "resource": {
+                    "status": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed",
+                    "description": "{{vars.demoMode}}\n\n##### Data Breach Report has been sent to the Data Protection Authority"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/tasks",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
             },
             "status": null,
-            "top": "165",
+            "top": "975",
             "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
-            "uuid": "2efd605d-779e-44a0-a8e3-cbb0f3c08b55"
+            "uuid": "519f8608-8203-4c96-9ab1-545316cd844e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Parent Incident ID",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "id",
+                            "value": "{{vars.complianceID}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "incidents"
+                    ]
+                },
+                "module": "data_compliances?$limit=30&$relationships=true",
+                "checkboxFields": true,
+                "step_variables": {
+                    "temp": "{% for item in vars.affectedUsersTempList %}{% set _dummy = \"|\" + loop.index | string + \"|\" + item + \"|\" %}{{vars.affectedIndividualsList.append(_dummy)}}{% endfor %}",
+                    "incidentIRI": "{{vars.result[0].incidents[0]['@id']}}"
+                }
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "82e27947-9f58-41b1-805d-779fe477b59d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Generate Breach Report",
+            "description": null,
+            "arguments": {
+                "name": "Report Engine",
+                "params": {
+                    "user_id": "{{vars.currentUser}}",
+                    "timezone": "{{vars.request.headers.tz}}",
+                    "report_id": "bd3f7e9b-45ba-4740-a617-164887fc754c",
+                    "query_params": "{\"qparam\": {\"complianceID\":{{vars.complianceID}}}}"
+                },
+                "version": "1.3.1",
+                "connector": "cyops-schedule-report",
+                "operation": "schedule_report_manual",
+                "operationTitle": "Generate Report From Report ID",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "ae5f6b3b-70ce-4271-8f4b-c57cb3c40dd2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Compliance Record ID",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "id",
+                            "value": "{{vars.input.records[0].id}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "dataCompliances"
+                    ]
+                },
+                "module": "tasks?$limit=30&$relationships=true",
+                "checkboxFields": true,
+                "step_variables": {
+                    "demoMode": "{% if vars.result[0].dataCompliances[0].testMode %}<span data-tomark-pass=\"\" style=\"border-radius: 25px; background: #73AD21; padding-left: 12px;padding-right: 12px;padding-top: 6px;padding-bottom: 6px;font-size: 11px;\"><strong>Test Mode ON<\/strong><\/span>{% endif %}",
+                    "dpaEmail": "{{vars.result[0].dataCompliances[0].dPAEmail}}",
+                    "demoEmail": "{{vars.result[0].dataCompliances[0].testEmail}}",
+                    "placeholder": "{% for item in vars.result[0].dataCompliances[0].description.split('\\n') %}\n{% if 'Notify Data Protection Authority' in item %}\n{% set _dummy = item | replace('10060', '9989') %}\n{{vars.description.append(_dummy)}}\n{% else %}\n{{vars.description.append(item)}}\n{% endif %}\n{% endfor %}",
+                    "complianceID": "{{vars.result[0].dataCompliances[0].id}}",
+                    "complianceIRI": "{{vars.result[0].dataCompliances[0]['@id']}}",
+                    "complianceName": "{{vars.result[0].dataCompliances[0].name}}",
+                    "breachNotificationDueDate": "{{vars.result[0].dataCompliances[0].breachNotificationDueDate}}"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "c97399d1-727c-4c8d-80fb-00bc37d2b32a"
         },
         {
             "@type": "WorkflowStep",
@@ -149,184 +315,18 @@
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "ecd60ed1-bc88-4ad3-9baf-55ecae81b0e8"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Compliance Record ID",
-            "description": null,
-            "arguments": {
-                "query": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "primitive",
-                            "field": "id",
-                            "value": "{{vars.input.records[0].id}}",
-                            "operator": "eq",
-                            "_operator": "eq"
-                        }
-                    ],
-                    "__selectFields": [
-                        "dataCompliances"
-                    ]
-                },
-                "module": "tasks?$limit=30&$relationships=true",
-                "checkboxFields": true,
-                "step_variables": {
-                    "demoMode": "{% if vars.result[0].dataCompliances[0].testMode %}<span data-tomark-pass=\"\" style=\"border-radius: 25px; background: #73AD21; padding-left: 12px;padding-right: 12px;padding-top: 6px;padding-bottom: 6px;font-size: 11px;\"><strong>Test Mode ON<\/strong><\/span>{% endif %}",
-                    "dpaEmail": "{{vars.result[0].dataCompliances[0].dPAEmail}}",
-                    "demoEmail": "{{vars.result[0].dataCompliances[0].testEmail}}",
-                    "placeholder": "{% for item in vars.result[0].dataCompliances[0].description.split('\\n') %}\n{% if 'Notify Data Protection Authority' in item %}\n{% set _dummy = item | replace('10060', '9989') %}\n{{vars.description.append(_dummy)}}\n{% else %}\n{{vars.description.append(item)}}\n{% endif %}\n{% endfor %}",
-                    "complianceID": "{{vars.result[0].dataCompliances[0].id}}",
-                    "complianceIRI": "{{vars.result[0].dataCompliances[0]['@id']}}",
-                    "complianceName": "{{vars.result[0].dataCompliances[0].name}}",
-                    "breachNotificationDueDate": "{{vars.result[0].dataCompliances[0].breachNotificationDueDate}}"
-                }
-            },
-            "status": null,
-            "top": "300",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
-            "group": null,
-            "uuid": "c97399d1-727c-4c8d-80fb-00bc37d2b32a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Task Status",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "status": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed",
-                    "description": "{{vars.demoMode}}\n\n##### Data Breach Report has been sent to the Data Protection Authority"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/tasks",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "975",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "519f8608-8203-4c96-9ab1-545316cd844e"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Compliance Record",
-            "description": null,
-            "arguments": {
-                "message": {
-                    "tags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "content": "<p>Data Breach Report has been sent to Data Protection Authority.<\/p>",
-                    "records": "{{vars.complianceIRI}},{{vars.incidentIRI}}"
-                },
-                "resource": {
-                    "status": "\/api\/3\/picklists\/bb73fd5e-f699-11e7-8c3f-9a214cf093ae",
-                    "description": "{{vars.description | join('\\n')}}",
-                    "resolvedDate": "{{arrow.utcnow().int_timestamp}}",
-                    "breachNotifiedOn": "{{arrow.utcnow().int_timestamp}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.complianceIRI}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/data_compliances",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1110",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "1b231c10-7a36-49e3-bc1d-c86d1f2ca09e"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Parent Incident ID",
-            "description": null,
-            "arguments": {
-                "query": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "primitive",
-                            "field": "id",
-                            "value": "{{vars.complianceID}}",
-                            "operator": "eq",
-                            "_operator": "eq"
-                        }
-                    ],
-                    "__selectFields": [
-                        "incidents"
-                    ]
-                },
-                "module": "data_compliances?$limit=30&$relationships=true",
-                "checkboxFields": true,
-                "step_variables": {
-                    "temp": "{% for item in vars.affectedUsersTempList %}{% set _dummy = \"|\" + loop.index | string + \"|\" + item + \"|\" %}{{vars.affectedIndividualsList.append(_dummy)}}{% endfor %}",
-                    "incidentIRI": "{{vars.result[0].incidents[0]['@id']}}"
-                }
-            },
-            "status": null,
-            "top": "435",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
-            "group": null,
-            "uuid": "82e27947-9f58-41b1-805d-779fe477b59d"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Breach Notified On Date",
-            "description": null,
-            "arguments": {
-                "message": {
-                    "tags": [
-                        "\/api\/3\/tags\/GDPR"
-                    ],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "content": "<p>Data Breach Report has been sent to Data Protection Authority.<\/p>",
-                    "records": "{{vars.complianceIRI}},{{vars.incidentIRI}}"
-                },
-                "resource": {
-                    "breachNotifiedOn": "{{arrow.utcnow().int_timestamp}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.complianceIRI}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/data_compliances",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "384da049-c718-4cff-af68-51107f92c56f"
         }
     ],
     "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Task Status -> Update Incident",
+            "targetStep": "\/api\/3\/workflow_steps\/1b231c10-7a36-49e3-bc1d-c86d1f2ca09e",
+            "sourceStep": "\/api\/3\/workflow_steps\/519f8608-8203-4c96-9ab1-545316cd844e",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "41a454ce-f9d5-4490-a34f-cdcc37f48c47"
+        },
         {
             "@type": "WorkflowRoute",
             "name": "Generate Breach Report -> Send Report to DPA",
@@ -338,21 +338,12 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/2efd605d-779e-44a0-a8e3-cbb0f3c08b55",
-            "sourceStep": "\/api\/3\/workflow_steps\/ecd60ed1-bc88-4ad3-9baf-55ecae81b0e8",
+            "name": "Update Breach Notified On Date -> Generate Breach Report",
+            "targetStep": "\/api\/3\/workflow_steps\/ae5f6b3b-70ce-4271-8f4b-c57cb3c40dd2",
+            "sourceStep": "\/api\/3\/workflow_steps\/384da049-c718-4cff-af68-51107f92c56f",
             "label": null,
             "isExecuted": false,
-            "uuid": "d1461817-3bb8-4b67-b6ba-a26bfe723773"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update Task Status -> Update Incident",
-            "targetStep": "\/api\/3\/workflow_steps\/1b231c10-7a36-49e3-bc1d-c86d1f2ca09e",
-            "sourceStep": "\/api\/3\/workflow_steps\/519f8608-8203-4c96-9ab1-545316cd844e",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "41a454ce-f9d5-4490-a34f-cdcc37f48c47"
+            "uuid": "b746240e-99a9-477e-a29a-8215b928dad9"
         },
         {
             "@type": "WorkflowRoute",
@@ -365,15 +356,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Configuration -> Get Compliance Record ID",
-            "targetStep": "\/api\/3\/workflow_steps\/c97399d1-727c-4c8d-80fb-00bc37d2b32a",
-            "sourceStep": "\/api\/3\/workflow_steps\/2efd605d-779e-44a0-a8e3-cbb0f3c08b55",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "ea5fac42-6316-4805-8738-73b30092cbff"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Send Report to DPA -> Update Task Status",
             "targetStep": "\/api\/3\/workflow_steps\/519f8608-8203-4c96-9ab1-545316cd844e",
             "sourceStep": "\/api\/3\/workflow_steps\/40eac1ff-8b76-42e4-88d4-e7030caf9ce7",
@@ -383,21 +365,30 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/2efd605d-779e-44a0-a8e3-cbb0f3c08b55",
+            "sourceStep": "\/api\/3\/workflow_steps\/ecd60ed1-bc88-4ad3-9baf-55ecae81b0e8",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "d1461817-3bb8-4b67-b6ba-a26bfe723773"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Get Compliance Record ID",
+            "targetStep": "\/api\/3\/workflow_steps\/c97399d1-727c-4c8d-80fb-00bc37d2b32a",
+            "sourceStep": "\/api\/3\/workflow_steps\/2efd605d-779e-44a0-a8e3-cbb0f3c08b55",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "ea5fac42-6316-4805-8738-73b30092cbff"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get Parent Incident ID -> Update Breach Notified On Date",
             "targetStep": "\/api\/3\/workflow_steps\/384da049-c718-4cff-af68-51107f92c56f",
             "sourceStep": "\/api\/3\/workflow_steps\/82e27947-9f58-41b1-805d-779fe477b59d",
             "label": null,
             "isExecuted": false,
             "uuid": "f930fbbc-fde5-4219-a5d9-bddeb5e67cca"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update Breach Notified On Date -> Generate Breach Report",
-            "targetStep": "\/api\/3\/workflow_steps\/ae5f6b3b-70ce-4271-8f4b-c57cb3c40dd2",
-            "sourceStep": "\/api\/3\/workflow_steps\/384da049-c718-4cff-af68-51107f92c56f",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "b746240e-99a9-477e-a29a-8215b928dad9"
         }
     ],
     "groups": [],


### PR DESCRIPTION
Mantis#0835037
- Validated the comment "Data Breach Report has been sent to Data Protection Authority." is not being added twice to the Data Compliance Record

Mantis#0835061
- Validated that the status of the Data Compliance record is updated to `In Progress` once the 'Submit Risk Assessment Information' task completed

Mantis#0835045
- Validated that the comment for `Notify Data Protection Officer` is displaying the correct severity for the Affected users

Mantis#0834995
- Validated the playbook to create a Data Compliance record will not be executed if the incident is already associated with the compliance record