### PR TITLE
QA Bugfixes

### DIFF
--- a/playbooks/10 - SP - GDPR Framework/Get Breach Report Reviewed and Approved by DPO.json
+++ b/playbooks/10 - SP - GDPR Framework/Get Breach Report Reviewed and Approved by DPO.json
@@ -94,7 +94,7 @@
                 }
             },
             "status": null,
-            "top": "1380",
+            "top": "1245",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -465,7 +465,7 @@
                 "unauthenticated_input": true
             },
             "status": null,
-            "top": "700",
+            "top": "705",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -542,6 +542,31 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Update Task",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "status": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed",
+                    "description": "{{vars.demoMode}}\n\n#### The 'Risk Assessment Information' has been reviewed by DPO\n\n{% if vars.steps.Send_Risk_Assessment_Details_to_DPO.input.impactSeverityOnAffectedUsers in ['High', 'Medium'] %}Go back to <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/data_compliances\/{{vars.complianceUUID}}\"> Data Compliance Record #{{vars.complianceID}}<\/a> to execute next task <span style=\"background: #5d636a; padding: 5px;\">**Notify Affected Individuals**<\/span>{% elif vars.steps.Send_Risk_Assessment_Details_to_DPO.input.isReportDpoApproved == 'Rejected' %}Go back to <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/data_compliances\/{{vars.complianceUUID}}\"> Data Compliance Record #{{vars.complianceID}}<\/a> to execute next task <span style=\"background: #5d636a; padding: 5px;\">**Get Updated Report from DPO**{% else %}Go back to <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/data_compliances\/{{vars.complianceUUID}}\"> Data Compliance Record #{{vars.complianceID}}<\/a> to execute next task <span style=\"background: #5d636a; padding: 5px;\">**Notify Data Protection Authority**<\/span>{% endif %}"
+                },
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/tasks",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1650",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "4c390508-754a-4d76-a0c7-eeb59a193673"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Is Valid Breach",
             "description": null,
             "arguments": {
@@ -561,7 +586,7 @@
                 ]
             },
             "status": null,
-            "top": "1110",
+            "top": "975",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -581,7 +606,8 @@
                 "__recommend": [],
                 "collectionType": "\/api\/3\/data_compliances",
                 "fieldOperation": {
-                    "recordTags": "Append"
+                    "recordTags": "Append",
+                    "reminderMailStatus": "Append"
                 },
                 "step_variables": []
             },
@@ -591,31 +617,6 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "85f2df31-28bd-4819-a48a-63a9f6890b3c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Task Status",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "status": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/tasks",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "975",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "8efeed9e-7065-4186-b616-a96315419b6f"
         },
         {
             "@type": "WorkflowStep",
@@ -636,7 +637,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "1245",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -684,7 +685,7 @@
                 }
             },
             "status": null,
-            "top": "1515",
+            "top": "1380",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -718,7 +719,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1110",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -754,7 +755,7 @@
                 }
             },
             "status": null,
-            "top": "440",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -792,6 +793,7 @@
                     "complianceID": "{{vars.result[0].dataCompliances[0].id}}",
                     "complianceIRI": "{{vars.result[0].dataCompliances[0]['@id']}}",
                     "complianceName": "{{vars.result[0].dataCompliances[0].name}}",
+                    "complianceUUID": "{{vars.result[0].dataCompliances[0].uuid}}",
                     "affectedUsersTempList": "{{vars.result[0].dataCompliances[0].affectedUsersEmails.split(',')}}",
                     "breachNotificationDueDate": "{{vars.result[0].dataCompliances[0].breachNotifyDueDate}}"
                 }
@@ -844,7 +846,7 @@
                     ],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Created <a title=\"Task #{{vars.result.id}} - {{vars.result.name}}\" href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.result.uuid}}\">Task #{{vars.result.id}} - {{vars.result.name}}<\/a> to send data breach report to Data Protection Authority.<\/p>",
+                    "content": "<p>Created <a href=\"https:\/\/{{globalVars.Server_fqhn}}\/modules\/view-panel\/tasks\/{{vars.result.uuid}}\" title=\"Task #{{vars.result.id}} - {{vars.result.name}}\">Task #{{vars.result.id}} - {{vars.result.name}}<\/a> to send data breach report to Data Protection Authority.<\/p>",
                     "records": "{{vars.complianceIRI}}"
                 },
                 "resource": {
@@ -874,7 +876,7 @@
                 }
             },
             "status": null,
-            "top": "1650",
+            "top": "1515",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -910,7 +912,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1110",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -947,12 +949,39 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Update Task  Description -> Update Compliance Record Description",
+            "targetStep": "\/api\/3\/workflow_steps\/85f2df31-28bd-4819-a48a-63a9f6890b3c",
+            "sourceStep": "\/api\/3\/workflow_steps\/4c390508-754a-4d76-a0c7-eeb59a193673",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "4feabf96-d2a2-4638-be5d-0fcbc7ecc7d0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create Task to Send Report to DPA -> Update Task  Description",
+            "targetStep": "\/api\/3\/workflow_steps\/4c390508-754a-4d76-a0c7-eeb59a193673",
+            "sourceStep": "\/api\/3\/workflow_steps\/d6b9971b-9a6c-460a-b71f-5bf0dec81abb",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "5c477221-f8fc-43ae-a0c0-2521186407f4"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Configuration",
             "targetStep": "\/api\/3\/workflow_steps\/1fb758b2-3161-4ad5-a13b-e74a86ea4e74",
             "sourceStep": "\/api\/3\/workflow_steps\/453ae9dd-e8bc-401d-8ca1-ab3927b0f1ee",
             "label": null,
             "isExecuted": false,
             "uuid": "5d650097-fc54-4c75-b2aa-cbb68de163e8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update GDPR Assessment Data -> Is Valid Breach",
+            "targetStep": "\/api\/3\/workflow_steps\/56b01d26-0f4d-41dc-b9f0-5961d7616dff",
+            "sourceStep": "\/api\/3\/workflow_steps\/d08ef5d7-19db-417c-91c3-d3631adbfb92",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "82ddc35a-a77d-4681-82fe-ee69d8caa1ac"
         },
         {
             "@type": "WorkflowRoute",
@@ -998,33 +1027,6 @@
             "label": "Submit",
             "isExecuted": false,
             "uuid": "c9500e34-6562-49a1-8daa-fec619215be4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update Task Status -> Is Valid Breach",
-            "targetStep": "\/api\/3\/workflow_steps\/56b01d26-0f4d-41dc-b9f0-5961d7616dff",
-            "sourceStep": "\/api\/3\/workflow_steps\/8efeed9e-7065-4186-b616-a96315419b6f",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "cc706b32-7eb0-495c-af64-1cc5a2acd9a9"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update GDPR Assessment Data -> Update Task Status",
-            "targetStep": "\/api\/3\/workflow_steps\/8efeed9e-7065-4186-b616-a96315419b6f",
-            "sourceStep": "\/api\/3\/workflow_steps\/d08ef5d7-19db-417c-91c3-d3631adbfb92",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "d1f55701-cd7f-40fc-a36e-261946fb6b07"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Task to Send Report to DPA -> Update Incident",
-            "targetStep": "\/api\/3\/workflow_steps\/85f2df31-28bd-4819-a48a-63a9f6890b3c",
-            "sourceStep": "\/api\/3\/workflow_steps\/d6b9971b-9a6c-460a-b71f-5bf0dec81abb",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "dc9caa3e-2e02-4af5-8ea3-12b97e0cfb73"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/10 - SP - GDPR Framework/Get Updated Data Breach Report from DPO.json
+++ b/playbooks/10 - SP - GDPR Framework/Get Updated Data Breach Report from DPO.json
@@ -565,7 +565,7 @@
                     ],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Received update Data Breach Report from Data Protection Officer.<\/p>",
+                    "content": "<p>Received updated Data Breach Report from Data Protection Officer.<\/p>",
                     "records": "{{vars.complianceIRI}},{{vars.incidentIRI}}"
                 },
                 "resource": {

--- a/playbooks/10 - SP - GDPR Framework/Provide DPO and DPA Contact.json
+++ b/playbooks/10 - SP - GDPR Framework/Provide DPO and DPA Contact.json
@@ -43,7 +43,7 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
                     "content": "<p>DPO and DPA contact details have been collected.<\/p>",
-                    "records": "{{vars.complianceIRI}}"
+                    "records": "{{vars.complianceIRI}},{{vars.incidentIRI}}"
                 },
                 "resource": {
                     "__link": {
@@ -64,12 +64,13 @@
                 "__recommend": [],
                 "collectionType": "\/api\/3\/data_compliances",
                 "fieldOperation": {
-                    "recordTags": "Append"
+                    "recordTags": "Append",
+                    "reminderMailStatus": "Append"
                 },
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -145,7 +146,7 @@
                 }
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -172,11 +173,47 @@
                 "workflowReference": "\/api\/3\/workflows\/77f188a6-d970-4397-81af-84cc3f10ac0d"
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "4761b636-27ee-423a-ba9a-c66697855d39"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Parent Incident ID",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "id",
+                            "value": "{{vars.complianceID}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "incidents"
+                    ]
+                },
+                "module": "data_compliances?$limit=30&$relationships=true",
+                "checkboxFields": true,
+                "step_variables": {
+                    "nextTask": "Notify Data Protection Authority",
+                    "incidentIRI": "{{vars.result[0].incidents[0]['@id']}}"
+                }
+            },
+            "status": null,
+            "top": "435",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "4f34d81d-467f-4c92-a299-1c1c9f08c45d"
         },
         {
             "@type": "WorkflowStep",
@@ -199,7 +236,7 @@
                 "workflowReference": "\/api\/3\/workflows\/77f188a6-d970-4397-81af-84cc3f10ac0d"
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -235,7 +272,7 @@
                 }
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -599,7 +636,7 @@
                 ]
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -625,7 +662,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -662,6 +699,15 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Get Compliance Record ID -> Get Parent Incident ID",
+            "targetStep": "\/api\/3\/workflow_steps\/4f34d81d-467f-4c92-a299-1c1c9f08c45d",
+            "sourceStep": "\/api\/3\/workflow_steps\/1c29f2f0-a13f-42a6-8e11-d9305d0cf098",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "374cf0a4-81df-401c-bf7d-1f968a4b2938"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Configuration -> Get Compliance Record ID",
             "targetStep": "\/api\/3\/workflow_steps\/1c29f2f0-a13f-42a6-8e11-d9305d0cf098",
             "sourceStep": "\/api\/3\/workflow_steps\/01e70d1f-e83b-46bf-a593-33d8aa447aed",
@@ -680,21 +726,21 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Compliance Record ID -> Demo Mode Status",
-            "targetStep": "\/api\/3\/workflow_steps\/eb8343e2-1395-4ba5-8334-da878f17e576",
-            "sourceStep": "\/api\/3\/workflow_steps\/1c29f2f0-a13f-42a6-8e11-d9305d0cf098",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "92d55446-822f-49e8-8a58-e5e9ddaa373c"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Update Task -> Update GDPR Assessment Data",
             "targetStep": "\/api\/3\/workflow_steps\/1129eb49-6b05-4984-80ad-ae314389126a",
             "sourceStep": "\/api\/3\/workflow_steps\/f815d59a-6075-4b03-9694-abe429b5eb86",
             "label": null,
             "isExecuted": false,
             "uuid": "93a1dbc9-16a9-47d5-9944-2a642dc5a50f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Parent Incident ID -> Test Mode Status",
+            "targetStep": "\/api\/3\/workflow_steps\/eb8343e2-1395-4ba5-8334-da878f17e576",
+            "sourceStep": "\/api\/3\/workflow_steps\/4f34d81d-467f-4c92-a299-1c1c9f08c45d",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "ad524d53-5619-4bf8-bdea-915b20e37600"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/10 - SP - GDPR Framework/Reminder for SLA Breach.json
+++ b/playbooks/10 - SP - GDPR Framework/Reminder for SLA Breach.json
@@ -12,7 +12,6 @@
     "parameters": [
         "dataComplianceMetaData",
         "secondReminderThreshold",
-        "firstReminderThreshold",
         "timeZone"
     ],
     "synchronous": false,
@@ -258,7 +257,7 @@
                     {
                         "option": "Breach Reminder",
                         "step_iri": "\/api\/3\/workflow_steps\/36cdf048-f8d9-413b-9840-888ea44e1f57",
-                        "condition": "{{ (vars.timeRemainToBreach | int < 0) }}",
+                        "condition": "{{ (vars.timeRemainToBreach | int < 0) and (\"GDPRReminderStatus\" | picklist(\"Breach Reminder Sent\", \"@id\") not in vars.reminderEmailStatus) }}",
                         "step_name": "SLA Breached Notification"
                     },
                     {


### PR DESCRIPTION
Mantis #0847907
- Modified `Get Updated Data Breach Report from DPO` playbook
- Validated that the comment 'Received update Data Breach Report from Data Protection Officer is modified to "Received updated Data Breach Report from Data Protection Officer"

Mantis #0827681
- Modified `Provide DPO and DPA Contact` playbook
- Validated that comment `DPO and DPA contact details have been collected is added to the parent incident as well

Mantis #0847902
- Modified `Get Breach Report Reviewed and Approved by DPO` playbook
- Validated that the description of a task "Notify Data Protection Officer" is changing according to the next task to be executed

Mantis #0811609
- Modified `Reminder for SLA Breach` playbooks
- Validated that variable "firstReminderThreshold" is now removed from the playbooks
- Also condition related to "Breach Notification Sent" is updated with the added condition to check the picklist value